### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/code/src/Attendee/Attendee.cs
+++ b/code/src/Attendee/Attendee.cs
@@ -9,7 +9,12 @@ namespace Attendees
     {
         public void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Entry is outside the target directory: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
         


### PR DESCRIPTION
Potential fix for [https://github.com/DennisSchouwenaars/skills-secure-repository-supply-chain/security/code-scanning/1](https://github.com/DennisSchouwenaars/skills-secure-repository-supply-chain/security/code-scanning/1)

To fix the issue, we need to validate the constructed file path to ensure it does not escape the intended destination directory. This involves:

1. Using `Path.GetFullPath` to resolve the full path of the constructed file (`destFileName`) and the destination directory (`destDirectory`).
2. Ensuring that the resolved file path starts with the resolved destination directory path.
3. Throwing an exception if the validation fails to prevent writing files outside the intended directory.

The fix will modify the `WriteToDirectory` method to include these validation steps before calling `entry.ExtractToFile`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
